### PR TITLE
feat: add seed for apartment_images table

### DIFF
--- a/seeds/safetrust/1734473134980_apartment_images_seed.sql
+++ b/seeds/safetrust/1734473134980_apartment_images_seed.sql
@@ -1,0 +1,34 @@
+-- Ensure UUID extension is enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Insert 3 images for "Modern Loft in Heredia"
+INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+VALUES
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in Heredia'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-1.jpg', 
+ NOW()),
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in Heredia'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-10-810x540.jpg', 
+ NOW()),
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in Heredia'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-9-810x531.jpg', 
+ NOW());
+
+-- Insert 3 images for "Modern Loft in San Jose"
+INSERT INTO apartment_images (id, apartment_id, image_url, uploaded_at)
+VALUES
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in San Jose'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-22-810x540.jpg', 
+ NOW()),
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in San Jose'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-18-810x540.jpg', 
+ NOW()),
+(uuid_generate_v4(), 
+ (SELECT id FROM apartments WHERE name = 'Modern Loft in San Jose'), 
+ 'https://design-milk.com/images/2024/02/Loft-M50-Turin-Paola-Mare-21-810x540.jpg', 
+ NOW());


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue https://github.com/safetrustcr/Backend/issues/51

❗ **Pull Request Information**

This pull request introduces a **complete seed script** for the `apartment_images` table. The script generates realistic test data, referencing existing apartments, to facilitate development and testing.

## 🌀 Summary of Changes

- **Created a new seed script**: `apartment_images_seed.sql` to populate the `apartment_images` table.  
- **Referenced existing apartment IDs**: Used subqueries to fetch apartment IDs based on their names.  
- **Generated realistic image URLs**: Added three images for each apartment.  
- **Ensured unique UUIDs**: Implemented `uuid_generate_v4()` to generate unique values for the `id` column.

## 🛠 Testing

### Evidence Before Solution

![image](https://github.com/user-attachments/assets/a5c23b6a-8767-4fdb-bb7f-2df294501998)

- Before applying the solution, the `apartment_images` table was empty, and no test data was available.  

### Evidence After Solution

- After applying the seed script, the `apartment_images` table contains realistic test data with three images for each of the following apartments:  
  - *Modern Loft in Heredia*  
  - *Modern Loft in San Jose*  

**Video**: [https://www.loom.com/share/525ed89abb9846969a53988cdc081917?sid=2eb68c47-69b2-4c67-81df-999705c56e7c](https://www.loom.com/share/525ed89abb9846969a53988cdc081917?sid=2eb68c47-69b2-4c67-81df-999705c56e7c)

## 📂 Related Issue

This pull request **will close Issue #51** upon being merged.

---

🎉 Thank you for reviewing this Pull Request! 🎉
