### PR TITLE
fix: deleted the public. statement

### DIFF
--- a/seeds/safetrust/1734721404143_escrow_xdr_transactions.sql
+++ b/seeds/safetrust/1734721404143_escrow_xdr_transactions.sql
@@ -1,4 +1,4 @@
-INSERT INTO public.escrow_xdr_transactions (
+INSERT INTO escrow_xdr_transactions (
     id, 
     escrow_transaction_id, 
     xdr_type, 


### PR DESCRIPTION
# Pull Request for SafeTrust - Close Issue

❗ **Pull Request Information**

<!-- Briefly describe the purpose of the pull request. Explain the problem being solved or the functionality being implemented. -->

This PR is for delete the public. statement from escrow_xdr_transactions.sql file because it is unnecesary and might generate conflicts because not always the tables are allocated in the public directory

## 🌀 Summary of Changes

<!-- List the main changes made in the code. Include new features, bug fixes, or refactored components. -->

- [x] Deleted the public. from escrow_xdr_transactions.sql file

## 🛠 Testing

### Evidence Before Solution

<!-- Describe the behavior or issue before applying the solution. Use Loom to record a video showing the problem. Provide a link to the video. -->

N/A

### Evidence After Solution

<!-- Explain how the issue was fixed and demonstrate the corrected functionality. Use Loom to record another video showing the solution. Provide a link to the video. -->

N/A


🎉 Thank you for reviewing this PR! 🎉
